### PR TITLE
Fix Vanilla Impostor

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ An Among Us mod that adds a bunch of roles, modifiers and game settings
  <details>
   <summary> v2.2.2: First release post-Polus.gg! </summary> 
   <ul>
+   <li> Fix the instant Game Over screen when there aren't enough Impostor roles. </li>
    <li> Fix for the Undertaker failing to drop a body. </li>
    <li> Seer can have a percentage chance of the sight failing. </li>
    <li> Snitch seeing the Impostors in meetings can be disabled. </li>

--- a/source/Patches/RpcHandling.cs
+++ b/source/Patches/RpcHandling.cs
@@ -133,7 +133,7 @@ namespace TownOfUs
             if (LoversOn)
                 Lover.Gen(crewmates, impostors);
 
-            while (impostors.Count > 0)
+            while (impostors.Count > 0 && ImpostorRoles.Count > 0)
             {
                 var (type, rpc, _) = ImpostorRoles.TakeFirst();
                 if (type == null) break;


### PR DESCRIPTION
I think I figured out why it crashes when there's insufficient impostor roles.