### PR TITLE
fix(Prophet): Fix initial reveal

### DIFF
--- a/source/Patches/Roles/Prophet.cs
+++ b/source/Patches/Roles/Prophet.cs
@@ -30,7 +30,7 @@ namespace TownOfUs.Roles
             // I think this will trigger a revelation as soon as the HUD hits
             if (CustomGameOptions.ProphetInitialReveal)
             {
-                LastRevealed = LastRevealed.AddMilliseconds(CustomGameOptions.ProphetCooldown * -1).AddSeconds(5);
+                LastRevealed = LastRevealed.AddSeconds(CustomGameOptions.ProphetCooldown * -1).AddSeconds(5);
             }
         }
 


### PR DESCRIPTION
Cooldown is in seconds, not milliseconds.