### PR TITLE
feat(Snitch): Restrict arrows to Snitch

### DIFF
--- a/source/Patches/CrewmateRoles/SnitchMod/CompleteTask.cs
+++ b/source/Patches/CrewmateRoles/SnitchMod/CompleteTask.cs
@@ -29,7 +29,8 @@ namespace TownOfUs.CrewmateRoles.SnitchMod
                     {
                         Coroutines.Start(Utils.FlashCoroutine(role.Color));
                     }
-                    else if (PlayerControl.LocalPlayer.Data.IsImpostor || PlayerControl.LocalPlayer.Is(RoleEnum.Glitch))
+                    else if (PlayerControl.LocalPlayer.Data.IsImpostor
+                             || (Role.GetRole<Snitch>(PlayerControl.LocalPlayer).Faction == Faction.Neutral && CustomGameOptions.SnitchSeesNeutrals))
                     {
                         Coroutines.Start(Utils.FlashCoroutine(role.Color));
                         var gameObj = new GameObject();


### PR DESCRIPTION
Now all neutral roles get an arrow to the Snitch, not just the Glitch.
This arrow only appears if the Snitch will be able to see neutral roles.