### PR TITLE
feat: Hook the initial kill cooldown

### DIFF
--- a/source/Patches/CustomGameOptions.cs
+++ b/source/Patches/CustomGameOptions.cs
@@ -98,6 +98,7 @@ namespace TownOfUs
         public static float MorphlingDuration => Generate.MorphlingDuration.Get();
         public static float CamouflagerCd => Generate.CamouflagerCooldown.Get();
         public static float CamouflagerDuration => Generate.CamouflagerDuration.Get();
+        public static float InitialImpostorKillCooldown => Generate.InitialImpostorKillCooldown.Get();
         public static bool ColourblindComms => Generate.ColourblindComms.Get();
         public static bool MeetingColourblind => Generate.MeetingColourblind.Get();
         public static OnTargetDead OnTargetDead => (OnTargetDead) Generate.OnTargetDead.Get();

--- a/source/Patches/CustomOption/Generate.cs
+++ b/source/Patches/CustomOption/Generate.cs
@@ -53,6 +53,7 @@ namespace TownOfUs.CustomOption
 
 
         private static CustomHeaderOption CustomGameSettings;
+        public static CustomNumberOption InitialImpostorKillCooldown;
         public static CustomToggleOption ColourblindComms;
         public static CustomToggleOption MeetingColourblind;
         public static CustomToggleOption ImpostorSeeRoles;
@@ -266,6 +267,8 @@ namespace TownOfUs.CustomOption
 
             CustomGameSettings =
                 new CustomHeaderOption(num++, "Custom Game Settings");
+            InitialImpostorKillCooldown = new CustomNumberOption(num++, "Initial Impostor Kill Cooldown", 10f, 10f, 60f,
+                2.5f, CooldownFormat);
             ColourblindComms = new CustomToggleOption(num++, "Camouflaged Comms", false);
             MeetingColourblind = new CustomToggleOption(num++, "Camouflaged Meetings", false);
             ImpostorSeeRoles = new CustomToggleOption(num++, "Impostors can see the roles of their team", false);

--- a/source/Patches/ImpostorRoles/ImpostorStartCooldown.cs
+++ b/source/Patches/ImpostorRoles/ImpostorStartCooldown.cs
@@ -1,0 +1,27 @@
+using System;
+using HarmonyLib;
+
+namespace TownOfUs.Patches.ImpostorRoles
+{
+    /*
+     * From the No Hack Too Cheap Department. We can patch the game start event and set the player's cooldown from
+     * unintialized zero to the cooldown we want. However, some event after that will run and set the cooldown to
+     * 10 for day 1. So what we do is set the cooldown to the value we want. Then we catch when the game attempts to
+     * set the starting cooldown to 10 and replace it.
+     */
+    [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.SetKillTimer))]
+    public static class PatchKillTimer
+    {
+        [HarmonyPriority(Priority.First)]
+        public static void Prefix(PlayerControl __instance, ref float time)
+        {
+            if (
+                PlayerControl.GameOptions.KillCooldown > 10
+                && __instance.Data.IsImpostor && time == 10
+                && (__instance.killTimer > time || __instance.killTimer == 0))
+            {
+                time = PlayerControl.GameOptions.KillCooldown;
+            }
+        }
+    }
+}

--- a/source/Patches/ImpostorRoles/ImpostorStartCooldown.cs
+++ b/source/Patches/ImpostorRoles/ImpostorStartCooldown.cs
@@ -20,7 +20,7 @@ namespace TownOfUs.Patches.ImpostorRoles
                 && __instance.Data.IsImpostor && time == 10
                 && (__instance.killTimer > time || __instance.killTimer == 0))
             {
-                time = PlayerControl.GameOptions.KillCooldown;
+                time = CustomGameOptions.InitialImpostorKillCooldown;
             }
         }
     }

--- a/source/Patches/ImpostorRoles/UnderdogMod/PatchKillTimer.cs
+++ b/source/Patches/ImpostorRoles/UnderdogMod/PatchKillTimer.cs
@@ -7,6 +7,7 @@ namespace TownOfUs.ImpostorRoles.UnderdogMod
     [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.SetKillTimer))]
     public static class PatchKillTimer
     {
+        [HarmonyPriority(Priority.Last)]
         public static bool Prefix(PlayerControl __instance, [HarmonyArgument(0)] float time)
         {
             var role = Role.GetRole(__instance);


### PR DESCRIPTION
This lets us hook the cooldown and reset it. Now we just need to figure out how exactly we want to let people customize the starting kill cooldown.