### PR TITLE
fix: Fix an error when loading saved settings

### DIFF
--- a/source/Patches/CustomOption/Import.cs
+++ b/source/Patches/CustomOption/Import.cs
@@ -135,7 +135,12 @@ namespace TownOfUs.CustomOption
                 var name = splitText[0].Trim();
                 splitText.RemoveAt(0);
                 var option = AllOptions.FirstOrDefault(o => o.Name.Equals(name, StringComparison.Ordinal));
-                if (option == null && splitText.Count > 0)
+                if (splitText.Count == 0)
+                {
+                    break;
+                }
+
+                if (option == null)
                 {
                     try
                     {


### PR DESCRIPTION
Apparently the code there relied on getting the exception when the thing was empty and my change overzealously broke this. Check for it explicitly so we don't get an exception.