### PR TITLE
Phantom Changes(ReducedTasks)

### DIFF
--- a/source/Patches/CustomGameOptions.cs
+++ b/source/Patches/CustomGameOptions.cs
@@ -117,6 +117,7 @@ namespace TownOfUs
         public static bool DeadSeeRoles => Generate.DeadSeeRoles.Get();
         public static float DouseCd => Generate.DouseCooldown.Get();
         public static bool ArsonistGameEnd => Generate.ArsonistGameEnd.Get();
+        public static int PhantomTaskWin => (int)Generate.PhantomTaskWin.Get();
         public static int MaxImpostorRoles => (int) Generate.MaxImpostorRoles.Get();
         public static int MaxNeutralRoles => (int) Generate.MaxNeutralRoles.Get();
         public static bool RoleUnderName => Generate.RoleUnderName.Get();

--- a/source/Patches/CustomOption/Generate.cs
+++ b/source/Patches/CustomOption/Generate.cs
@@ -154,6 +154,9 @@ namespace TownOfUs.CustomOption
         public static CustomNumberOption DouseCooldown;
         public static CustomToggleOption ArsonistGameEnd;
 
+        private static CustomHeaderOption Phantom;
+        public static CustomNumberOption PhantomTaskWin;
+
         private static CustomHeaderOption Executioner;
         public static CustomStringOption OnTargetDead;
 
@@ -457,6 +460,9 @@ namespace TownOfUs.CustomOption
             DouseCooldown =
                 new CustomNumberOption(num++, "Douse Cooldown", 25, 10, 40, 2.5f, CooldownFormat);
             ArsonistGameEnd = new CustomToggleOption(num++, "Game keeps going so long as Arsonist is alive", false);
+            Phantom = new CustomHeaderOption(num++, "<color=#662962>Phantom</color>");
+            PhantomTaskWin =
+                new CustomNumberOption(num++, "Tasks To Win", 75, 50, 100, 5f, PercentFormat);
             #endregion
 
 

--- a/source/Patches/NeutralRoles/PhantomMod/SetPhantom.cs
+++ b/source/Patches/NeutralRoles/PhantomMod/SetPhantom.cs
@@ -53,16 +53,7 @@ namespace TownOfUs.NeutralRoles.PhantomMod
             //var startingVent = ShipStatus.Instance.AllVents[5];
             var startingVent =
                 ShipStatus.Instance.AllVents[Random.RandomRangeInt(0, ShipStatus.Instance.AllVents.Count)];
-
-            Logger<TownOfUs>.Instance.LogDebug($"MapID=" + PlayerControl.GameOptions.MapId.ToString());
-            Logger<TownOfUs>.Instance.LogDebug($"StartingVent.Id=" + startingVent.Id.ToString());
-            Vector2 ventpos = startingVent.transform.position;
-            if(PlayerControl.GameOptions.MapId==2 && startingVent.Id==5)
-            {
-                //fixing bugged vent on polus next to admin table
-                ventpos.y = ventpos.y - -1;
-            }
-            PlayerControl.LocalPlayer.NetTransform.RpcSnapTo(ventpos);
+            PlayerControl.LocalPlayer.NetTransform.RpcSnapTo(startingVent.transform.position);
             PlayerControl.LocalPlayer.MyPhysics.RpcEnterVent(startingVent.Id);
         }
 

--- a/source/Patches/NeutralRoles/PhantomMod/SetPhantom.cs
+++ b/source/Patches/NeutralRoles/PhantomMod/SetPhantom.cs
@@ -47,9 +47,6 @@ namespace TownOfUs.NeutralRoles.PhantomMod
             }
 
             if (Role.GetRole<Phantom>(PlayerControl.LocalPlayer).Caught) return;
-
-            //for testing buggy office vent on polus only.
-            //var startingVent = ShipStatus.Instance.AllVents[5];
             var startingVent =
                 ShipStatus.Instance.AllVents[Random.RandomRangeInt(0, ShipStatus.Instance.AllVents.Count)];
             PlayerControl.LocalPlayer.NetTransform.RpcSnapTo(startingVent.transform.position);

--- a/source/Patches/NeutralRoles/PhantomMod/SetPhantom.cs
+++ b/source/Patches/NeutralRoles/PhantomMod/SetPhantom.cs
@@ -1,6 +1,7 @@
 using System;
 using HarmonyLib;
 using Hazel;
+using Reactor;
 using TownOfUs.Roles;
 using UnityEngine;
 using UnityEngine.UI;
@@ -47,9 +48,21 @@ namespace TownOfUs.NeutralRoles.PhantomMod
             }
 
             if (Role.GetRole<Phantom>(PlayerControl.LocalPlayer).Caught) return;
+
+            //for testing buggy office vent on polus only.
+            //var startingVent = ShipStatus.Instance.AllVents[5];
             var startingVent =
                 ShipStatus.Instance.AllVents[Random.RandomRangeInt(0, ShipStatus.Instance.AllVents.Count)];
-            PlayerControl.LocalPlayer.NetTransform.RpcSnapTo(startingVent.transform.position);
+
+            Logger<TownOfUs>.Instance.LogDebug($"MapID=" + PlayerControl.GameOptions.MapId.ToString());
+            Logger<TownOfUs>.Instance.LogDebug($"StartingVent.Id=" + startingVent.Id.ToString());
+            Vector2 ventpos = startingVent.transform.position;
+            if(PlayerControl.GameOptions.MapId==2 && startingVent.Id==5)
+            {
+                //fixing bugged vent on polus next to admin table
+                ventpos.y = ventpos.y - -1;
+            }
+            PlayerControl.LocalPlayer.NetTransform.RpcSnapTo(ventpos);
             PlayerControl.LocalPlayer.MyPhysics.RpcEnterVent(startingVent.Id);
         }
 
@@ -81,6 +94,8 @@ namespace TownOfUs.NeutralRoles.PhantomMod
                     var taskInfo = player.Data.FindTaskById(task.Id);
                     taskInfo.Complete = false;
                 }
+            //TODO: this works here, but should also work if placed at the start of this method.
+            Utils.ModifyTaskCount(player, CustomGameOptions.PhantomTaskWin);
         }
 
         /*public static void ResetTowels(NormalPlayerTask task)

--- a/source/Patches/NeutralRoles/PhantomMod/SetPhantom.cs
+++ b/source/Patches/NeutralRoles/PhantomMod/SetPhantom.cs
@@ -1,7 +1,6 @@
 using System;
 using HarmonyLib;
 using Hazel;
-using Reactor;
 using TownOfUs.Roles;
 using UnityEngine;
 using UnityEngine.UI;

--- a/source/Patches/Utils.cs
+++ b/source/Patches/Utils.cs
@@ -303,6 +303,7 @@ namespace TownOfUs
 
         public static void ModifyTaskCount(PlayerControl player, int taskpercentage)
         {
+            //should this really be limited to only phantom? this could have other purposes.
             if (PlayerControl.LocalPlayer.Is(RoleEnum.Phantom))
             {
                 Logger<TownOfUs>.Instance.LogDebug($"taskpercentagechange=" + taskpercentage);
@@ -378,10 +379,90 @@ namespace TownOfUs
                 }
                 Logger<TownOfUs>.Instance.LogMessage($"OLD Tasks Count (ST/LT/CT)=" + ST + "/" + LT + "/" + CT);
                 Logger<TownOfUs>.Instance.LogMessage($"NEW Tasks Count (ST/LT/CT)=" + NewST + "/" + NewLT + "/" + NewCT);
+
+                #endregion weighting calculation
+
+                //WIP:- new task removal, not working yet
+                /*int STdiff = 0;
+                int LTdiff = 0;
+                int CTdiff = 0;
+                int totaldiff = 0;
+                STdiff = ST - NewST;
+                LTdiff = LT - NewLT;
+                CTdiff = CT - NewCT;
+                totaldiff = STdiff + LTdiff + CTdiff;
+                int flag = -1;
+
+                List<string> mytasks = new List<string>();
+                List<Tuple<string,string>> alltasks = new List<Tuple<string,string>>();
+
+                foreach (var task in player.myTasks)
+                {
+                    mytasks.Add(task.name);
+                    if (flag == -1)
+                    {
+                        foreach (var shorttask in ShipStatus.Instance.NormalTasks)
+                        {
+                            alltasks.Add(new Tuple<string, string>("Short", shorttask.name));
+                            if (STdiff > 0 && task.name.Contains(shorttask.name))
+                            {
+                                Logger<TownOfUs>.Instance.LogMessage($"ShortTaskRemoved:- {task.name} aka {shorttask.name}");
+                                player.myTasks.Remove(task);
+                                STdiff--;
+                                flag = 0;
+                                //break;
+                            }
+                        }
+                    }
+                    if (flag == -1)
+                    {
+                        foreach (var longtask in ShipStatus.Instance.LongTasks)
+                        {
+                            alltasks.Add(new Tuple<string, string>("Long", longtask.name));
+                            if (LTdiff > 0 && task.name.Contains(longtask.name))
+                            {
+                                Logger<TownOfUs>.Instance.LogMessage($"LongTaskRemoved:- {task.name} aka {longtask.name}");
+                                player.myTasks.Remove(task);
+                                LTdiff--;
+                                flag = 1;
+                                //break;
+                            }
+                        }
+                    }
+                    if (flag == -1)
+                    {
+                        foreach (var specialtask in ShipStatus.Instance.SpecialTasks)
+                        {
+                            alltasks.Add(new Tuple<string, string>("Special", specialtask.name));
+                            if (CTdiff > 0 && task.name.Contains(specialtask.name))
+                            {
+                                Logger<TownOfUs>.Instance.LogMessage($"SpecialTaskRemoved:- {task.name} aka {specialtask.name}");
+                                player.myTasks.Remove(task);
+                                CTdiff--;
+                                flag = 2;
+                                //break;
+                            }
+                        }
+                    }
+                    Logger<TownOfUs>.Instance.LogMessage($"Tasks To Remove Count (ST/LT/CT)=" + STdiff + "/" + LTdiff + "/" + CTdiff);
+                    flag = -1;
+                }
+                Logger<TownOfUs>.Instance.LogMessage($"Task Removal Ended!");
+
+                foreach (var t in mytasks)
+                {
+                    Logger<TownOfUs>.Instance.LogMessage($"MyTasks:- {t}");
+                }
+
+                Logger<TownOfUs>.Instance.LogMessage($" ----- ");
+                foreach (var t in alltasks)
+                {
+                    Logger<TownOfUs>.Instance.LogMessage($"AllTasks:- {t.Item1}/{t.Item2}");
+                }*/
+
                 //TODO: not weighted properly yet so tasks removed will be random.
                 int TaskDifference = NewST + NewLT + NewCT - ST - LT - CT;
 
-                #endregion weighting calculation
                 Logger<TownOfUs>.Instance.LogDebug($"TaskDifference=" + TaskDifference);
                 if (TaskDifference == 0)
                 {
@@ -413,7 +494,7 @@ namespace TownOfUs
                 else if (TaskDifference > 0)
                 {
                     //TODO: dont know yet how this would be handled so percentages higher than 100% should be disabled for now
-                }
+                }/**/
             }
         }
 

--- a/source/Patches/Utils.cs
+++ b/source/Patches/Utils.cs
@@ -276,8 +276,6 @@ namespace TownOfUs
             StopKill.BreakShield(medicIc, target.PlayerId, CustomGameOptions.ShieldBreaks);
         }
 
-        
-
         public static PlayerControl getClosestPlayer(PlayerControl refPlayer, List<PlayerControl> AllPlayers)
         {
             var num = double.MaxValue;
@@ -335,7 +333,7 @@ namespace TownOfUs
             {
                 if (task.name.Contains(listedTask))
                 {
-                    Logger<TownOfUs>.Instance.LogMessage($"{player.name} -> TaskRemoved:- {task.name} aka {listedTask}");
+                    Reactor.Logger<TownOfUs>.Instance.LogMessage($"{player.name} -> TaskRemoved:- {task.name} aka {listedTask}");
                     player.myTasks.Remove(task);
                     //task successfully removed
                     return true;
@@ -345,12 +343,12 @@ namespace TownOfUs
             return false;
         }
 
-        public static void ModifyTaskCount(PlayerControl player, int taskpercentage)
+        public static void ModifyTaskCount(PlayerControl player, int taskPercentage)
         {
             //should this really be limited to only phantom? this could have other purposes.
             if (PlayerControl.LocalPlayer.Is(RoleEnum.Phantom))
             {
-                Logger<TownOfUs>.Instance.LogDebug($"taskpercentagechange=" + taskpercentage);
+                Reactor.Logger<TownOfUs>.Instance.LogDebug($"taskpercentagechange=" + taskPercentage);
 
                 int CT = PlayerControl.GameOptions.NumCommonTasks;
                 int LT = PlayerControl.GameOptions.NumLongTasks;
@@ -358,118 +356,118 @@ namespace TownOfUs
 
                 #region weighting calcuation
                 //this whole region is all weighting calculation.. the calculation works, but no clue how to add/remove individual task types so this is currently pointless.
-                int CTWeight = 6; // should be 1 of these for 2 LT for 3 ST
-                int LTWeight = 3;
-                int STWeight = 1;
+                int ctWeight = 6; // should be 1 of these for 2 LT for 3 ST
+                int ltWeight = 3;
+                int stWeight = 1;
 
 
                 //must be floats for WeightedTasksValue and NewWeightedTasksValue otherwise rounding is incorrect
-                float WeightedTasksValue = (CT * CTWeight) + (LT * LTWeight) +
-                     (ST * STWeight);
-                Logger<TownOfUs>.Instance.LogDebug($"weightedtaskvalue=" + WeightedTasksValue.ToString());
+                float weightedTasksValue = (CT * ctWeight) + (LT * ltWeight) +
+                     (ST * stWeight);
+                Reactor.Logger<TownOfUs>.Instance.LogDebug($"weightedtaskvalue=" + weightedTasksValue.ToString());
 
-                float NewWeightedTasksValue = (WeightedTasksValue * taskpercentage) / 100;
+                float newWeightedTasksValue = (weightedTasksValue * taskPercentage) / 100;
 
-                Logger<TownOfUs>.Instance.LogDebug($"newweightedtaskvalue=" + NewWeightedTasksValue.ToString());
+                Reactor.Logger<TownOfUs>.Instance.LogDebug($"newweightedtaskvalue=" + newWeightedTasksValue.ToString());
 
 
-                int NewWTV = (int)Math.Ceiling(NewWeightedTasksValue);
-                Logger<TownOfUs>.Instance.LogDebug($"newWTV=" + NewWTV.ToString());
-                int NewCT = 0;
-                int NewLT = 0;
-                int NewST = 0;
+                int newWTV = (int)Math.Ceiling(newWeightedTasksValue);
+                Reactor.Logger<TownOfUs>.Instance.LogDebug($"newWTV=" + newWTV.ToString());
+                int newCT = 0;
+                int newLT = 0;
+                int newST = 0;
 
                 bool CTB = true, LTB = true, STB = false;
-                for (int w = 0; w <= NewWTV; w++)
+                for (int w = 0; w <= newWTV; w++)
                 {
 
-                    Logger<TownOfUs>.Instance.LogDebug($"w=" + w.ToString());
-                    Logger<TownOfUs>.Instance.LogDebug($"CTB=" + CTB.ToString());
-                    Logger<TownOfUs>.Instance.LogDebug($"LTB=" + LTB.ToString());
-                    Logger<TownOfUs>.Instance.LogDebug($"STB=" + STB.ToString());
+                    Reactor.Logger<TownOfUs>.Instance.LogDebug($"w=" + w.ToString());
+                    Reactor.Logger<TownOfUs>.Instance.LogDebug($"CTB=" + CTB.ToString());
+                    Reactor.Logger<TownOfUs>.Instance.LogDebug($"LTB=" + LTB.ToString());
+                    Reactor.Logger<TownOfUs>.Instance.LogDebug($"STB=" + STB.ToString());
 
                     //if the weighting of each task type is changed, the higher task weight should be the first if in these if/else statments and the true/false's will need modifying
-                    if (w + CTWeight <= NewWTV && NewCT < CT && CTB == false)
+                    if (w + ctWeight <= newWTV && newCT < CT && CTB == false)
                     {
-                        NewCT += 1;
-                        Logger<TownOfUs>.Instance.LogDebug($"NewCT=" + NewCT.ToString());
-                        w += CTWeight - 1;
+                        newCT += 1;
+                        Reactor.Logger<TownOfUs>.Instance.LogDebug($"NewCT=" + newCT.ToString());
+                        w += ctWeight - 1;
                         CTB = true;
                         LTB = true;
                         STB = false;
                     }
-                    else if (w + LTWeight <= NewWTV && NewLT < LT && LTB == false)
+                    else if (w + ltWeight <= newWTV && newLT < LT && LTB == false)
                     {
-                        NewLT += 1;
-                        Logger<TownOfUs>.Instance.LogDebug($"NewLT=" + NewLT.ToString());
-                        w += LTWeight - 1;
+                        newLT += 1;
+                        Reactor.Logger<TownOfUs>.Instance.LogDebug($"NewLT=" + newLT.ToString());
+                        w += ltWeight - 1;
                         CTB = true;
                         LTB = true;
                         STB = false;
                     }
-                    else if (w + STWeight <= NewWTV && NewST < ST && STB == false)
+                    else if (w + stWeight <= newWTV && newST < ST && STB == false)
                     {
-                        NewST += 1;
-                        Logger<TownOfUs>.Instance.LogDebug($"NewST=" + NewST.ToString());
-                        w += STWeight - 1;
+                        newST += 1;
+                        Reactor.Logger<TownOfUs>.Instance.LogDebug($"NewST=" + newST.ToString());
+                        w += stWeight - 1;
                         CTB = false;
                         LTB = false;
                         STB = true;
                     }
                     else
                     {
-                        Logger<TownOfUs>.Instance.LogDebug($"None Added");
+                        Reactor.Logger<TownOfUs>.Instance.LogDebug($"None Added");
                         CTB = false;
                         LTB = false;
                         STB = false;
                     }
                 }
-                Logger<TownOfUs>.Instance.LogDebug($"OLD Tasks Count (ST/LT/CT)=" + ST + "/" + LT + "/" + CT);
-                Logger<TownOfUs>.Instance.LogDebug($"NEW Tasks Count (ST/LT/CT)=" + NewST + "/" + NewLT + "/" + NewCT);
+                Reactor.Logger<TownOfUs>.Instance.LogDebug($"OLD Tasks Count (ST/LT/CT)=" + ST + "/" + LT + "/" + CT);
+                Reactor.Logger<TownOfUs>.Instance.LogDebug($"NEW Tasks Count (ST/LT/CT)=" + newST + "/" + newLT + "/" + newCT);
 
                 #endregion weighting calculation
 
                 //new task removal, seems to be working 100% correct.
-                int STdiff = ST - NewST;
-                int LTdiff = LT - NewLT;
-                int CTdiff = CT - NewCT;
+                int STdiff = ST - newST;
+                int LTdiff = LT - newLT;
+                int CTdiff = CT - newCT;
                 int totaldiff = STdiff + LTdiff + CTdiff;
                 int tasksremoved = 0;
 
-                List<Tuple<string, string>> alltasks = new List<Tuple<string, string>>();
+                List<Tuple<string, string>> allTasks = new List<Tuple<string, string>>();
                 Tuple<List<string>, List<string>, List<string>> mapTasks = GatherMapTasks();
 
                 foreach (var task in mapTasks.Item1)
                 {
-                    alltasks.Add(new Tuple<string, string>("Short", task));
+                    allTasks.Add(new Tuple<string, string>("Short", task));
                 }
                 foreach (var task in mapTasks.Item2)
                 {
-                    alltasks.Add(new Tuple<string, string>("Long", task));
+                    allTasks.Add(new Tuple<string, string>("Long", task));
                 }
                 foreach (var task in mapTasks.Item3)
                 {
-                    alltasks.Add(new Tuple<string, string>("Special", task));
+                    allTasks.Add(new Tuple<string, string>("Special", task));
                 }
                 foreach(var task in player.myTasks)
                 {
-                    alltasks.Add(new Tuple<string, string>("MyTasks", task.name));
+                    allTasks.Add(new Tuple<string, string>("MyTasks", task.name));
                 }
 
                 for (int i = 1; i <= totaldiff; i++)
                 {
-                    Logger<TownOfUs>.Instance.LogDebug($"i={i}");
-                    Logger<TownOfUs>.Instance.LogDebug($"STdiff={STdiff}");
-                    Logger<TownOfUs>.Instance.LogDebug($"LTdiff={LTdiff}");
-                    Logger<TownOfUs>.Instance.LogDebug($"CTdiff={CTdiff}");
+                    Reactor.Logger<TownOfUs>.Instance.LogDebug($"i={i}");
+                    Reactor.Logger<TownOfUs>.Instance.LogDebug($"STdiff={STdiff}");
+                    Reactor.Logger<TownOfUs>.Instance.LogDebug($"LTdiff={LTdiff}");
+                    Reactor.Logger<TownOfUs>.Instance.LogDebug($"CTdiff={CTdiff}");
                     if (STdiff > 0)
                     {
                         foreach (var task in player.myTasks)
                         {
-                            Logger<TownOfUs>.Instance.LogDebug($"ST Task.Name={task.name}");
+                            Reactor.Logger<TownOfUs>.Instance.LogDebug($"ST Task.Name={task.name}");
                             if (SearchAndRemoveTaskByList(player, task, mapTasks.Item1))
                             {
-                                Logger<TownOfUs>.Instance.LogDebug($"ST Task Removed:- {task.name}");
+                                Reactor.Logger<TownOfUs>.Instance.LogDebug($"ST Task Removed:- {task.name}");
                                 tasksremoved++;
                                 break;
                             }
@@ -482,10 +480,10 @@ namespace TownOfUs
                     {
                         foreach (var task in player.myTasks)
                         {
-                            Logger<TownOfUs>.Instance.LogDebug($"LT Task.Name={task.name}");
+                            Reactor.Logger<TownOfUs>.Instance.LogDebug($"LT Task.Name={task.name}");
                             if (SearchAndRemoveTaskByList(player, task, mapTasks.Item2))
                             {
-                                Logger<TownOfUs>.Instance.LogDebug($"LT Task Removed:- {task.name}");
+                                Reactor.Logger<TownOfUs>.Instance.LogDebug($"LT Task Removed:- {task.name}");
                                 tasksremoved++;
                                 break;
                             }
@@ -498,10 +496,10 @@ namespace TownOfUs
                     {
                         foreach (var task in player.myTasks)
                         {
-                            Logger<TownOfUs>.Instance.LogDebug($"CT Task.Name={task.name}");
+                            Reactor.Logger<TownOfUs>.Instance.LogDebug($"CT Task.Name={task.name}");
                             if (SearchAndRemoveTaskByList(player, task, mapTasks.Item3))
                             {
-                                Logger<TownOfUs>.Instance.LogDebug($"CT Task Removed:- {task.name}");
+                                Reactor.Logger<TownOfUs>.Instance.LogDebug($"CT Task Removed:- {task.name}");
                                 tasksremoved++;
                                 break;
                             }
@@ -512,15 +510,15 @@ namespace TownOfUs
                     }
                 }
 
-                Logger<TownOfUs>.Instance.LogDebug($"Remaining Tasks Diff (ST/LT/CT=tasksremoved)=" + STdiff + "/" + LTdiff + "/" + CTdiff+ "="+ tasksremoved);
-                Logger<TownOfUs>.Instance.LogDebug($"Task Removal Ended!");
+                Reactor.Logger<TownOfUs>.Instance.LogDebug($"Remaining Tasks Diff (ST/LT/CT=tasksremoved)=" + STdiff + "/" + LTdiff + "/" + CTdiff+ "="+ tasksremoved);
+                Reactor.Logger<TownOfUs>.Instance.LogDebug($"Task Removal Ended!");
 
                 //strictly a list of all tasks (phantom and all map tasks)
-                Logger<TownOfUs>.Instance.LogDebug($" ----- ");
-                Logger<TownOfUs>.Instance.LogDebug($"List of All Tasks (player(MyTasks) + map(Short/Long/Special).. special is Common Tasks + role/modifier added tasks");
-                foreach (var t in alltasks)
+                Reactor.Logger<TownOfUs>.Instance.LogDebug($" ----- ");
+                Reactor.Logger<TownOfUs>.Instance.LogDebug($"List of All Tasks (player(MyTasks) + map(Short/Long/Special).. special is Common Tasks + role/modifier added tasks");
+                foreach (var t in allTasks)
                 {
-                    Logger<TownOfUs>.Instance.LogDebug($"AllTasks:- {t.Item1}/{t.Item2}");
+                    Reactor.Logger<TownOfUs>.Instance.LogDebug($"AllTasks:- {t.Item1}/{t.Item2}");
                 }
 
                 //TODO: old code, this is not weighted properly yet so tasks removed will be random. do not use unless new task removal proves to be not working.

--- a/source/Patches/Utils.cs
+++ b/source/Patches/Utils.cs
@@ -16,7 +16,6 @@ using UnityEngine;
 using Object = UnityEngine.Object;
 using Random = UnityEngine.Random;
 using PerformKill = TownOfUs.ImpostorRoles.UnderdogMod.PerformKill;
-using Reactor;
 
 namespace TownOfUs
 {


### PR DESCRIPTION
a fix to add a setting for reducing the phantoms tasks.. 100% = normal tasks, 50% = half tasks, 5% increments inbetween, currently only random tasks are removed, but i have tried to put in a framework calculation for take a balanced amount of tasks from short, long and common tasks, so if someone knows how to remove a specific task type, then changing it to that will be the final piece to the puzzle.

Also fixed the Polus Admin Phantom Vent Spawn bug by shifting the location up on the Y axis by 1 point.

I have limited this change to only this vent, but using the same change i have made for this, it can be applied to other vents, just needs further if-statements.