### PR TITLE
feat(Lover): Turn Loving Impostor to a checkbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,14 +609,14 @@ They gain the primary objective to stay alive together.\
 If they are both among the last 3 players, they win.\
 In order to so, they gain access to a private chat, only visible by them in between meetings.\
 However, they can also win with their respective team, hence why the Lovers do not know the role of the other lover.\
-By default the second Lover will be an Impostor 25% of the time but only if there are 2 or more Impostors in the game.
+The second Lover will be an Impostor 25% of the time.
 
 ### Game Options
 | Name | Description | Type | Default |
 |----------|:-------------:|:------:|:------:|
 | Lovers | The percentage probability of the Lovers appearing | Percentage | 0% |
 | Both Lovers Die | Whether the other Lover automatically dies if the other does | Toggle | True |
-| Allow Loving Impostor | Whether one of the Lovers can be an Impostor | Percentage | 25% |
+| Allow Loving Impostor | Whether one of the Lovers can be an Impostor | Toggle | True |
 
 -----------------------
 ## Sheriff

--- a/source/Patches/CustomGameOptions.cs
+++ b/source/Patches/CustomGameOptions.cs
@@ -51,7 +51,7 @@ namespace TownOfUs
         public static int ButtonBarryOn => (int) Generate.ButtonBarryOn.Get();
         public static int VanillaGame => (int) Generate.VanillaGame.Get();
         public static bool BothLoversDie => Generate.BothLoversDie.Get();
-        public static int LovingImpostorOn => (int) Generate.LovingImpostorOn.Get();
+        public static bool LovingImpostorOn => Generate.LovingImpostorOn.Get();
         public static bool ShowSheriff => Generate.ShowSheriff.Get();
         public static bool SheriffKillOther => Generate.SheriffKillOther.Get();
         public static bool SheriffKillsJester => Generate.SheriffKillsJester.Get();
@@ -173,7 +173,7 @@ namespace TownOfUs
                 }
                 else if (faction == Faction.Impostors)
                 {
-                    if (On(LoversOn) && On(LovingImpostorOn)) enabledRoles.Add(RoleEnum.LoverImpostor);
+                    if (On(LoversOn) && LovingImpostorOn) enabledRoles.Add(RoleEnum.LoverImpostor);
                     if (On(MinerOn)) enabledRoles.Add(RoleEnum.Miner);
                     if (On(SwooperOn)) enabledRoles.Add(RoleEnum.Swooper);
                     if (On(MorphlingOn)) enabledRoles.Add(RoleEnum.Morphling);

--- a/source/Patches/CustomOption/Generate.cs
+++ b/source/Patches/CustomOption/Generate.cs
@@ -76,7 +76,7 @@ namespace TownOfUs.CustomOption
 
         private static CustomHeaderOption Lovers;
         public static CustomToggleOption BothLoversDie;
-        public static CustomNumberOption LovingImpostorOn;
+        public static CustomToggleOption LovingImpostorOn;
 
         private static CustomHeaderOption Sheriff;
         public static CustomToggleOption ShowSheriff;
@@ -330,8 +330,7 @@ namespace TownOfUs.CustomOption
             Lovers =
                 new CustomHeaderOption(num++, $"{RoleDetailsAttribute.GetRoleDetails(RoleEnum.Lover).WrapTextInColor("Lovers")}");
             BothLoversDie = new CustomToggleOption(num++, "Both Lovers Die");
-            LovingImpostorOn = new CustomNumberOption(num++, "Allow Loving Impostor",25f, 0f, 100f, 10f,
-                PercentFormat);
+            LovingImpostorOn = new CustomToggleOption(num++, "Allow Loving Impostor");
 
             Sheriff =
                 new CustomHeaderOption(num++, $"{RoleDetailsAttribute.GetRoleDetails(RoleEnum.Sheriff).GetColoredName()}");

--- a/source/Patches/CustomOption/Number.cs
+++ b/source/Patches/CustomOption/Number.cs
@@ -29,7 +29,7 @@ namespace TownOfUs.CustomOption
             return (float) Value;
         }
 
-       
+
         protected internal void Increase()
         {
             var increment = Increment > 5 && Input.GetKeyInt(KeyCode.LeftShift)

--- a/source/Patches/Roles/Lover.cs
+++ b/source/Patches/Roles/Lover.cs
@@ -61,15 +61,15 @@ namespace TownOfUs.Roles
 
         public static void Gen(List<PlayerControl> crewmates, List<PlayerControl> impostors)
         {
-            var lovingImpostorEnabled = Random.RandomRangeInt(1, 101) <= CustomGameOptions.LovingImpostorOn;
+            bool lovingImpostorEnabled = CustomGameOptions.LovingImpostorOn && Random.RandomRangeInt(0, 3) == 0;
 
-            var canMakeCrewCrewLovers = crewmates.Count >= 2;
-            var canMakeCrewImpostorLovers = crewmates.Count >= 1 && impostors.Count >= 2 && lovingImpostorEnabled;
+            bool canMakeCrewCrewLovers = crewmates.Count >= 2;
+            bool canMakeCrewImpostorLovers = crewmates.Count >= 1 && impostors.Count >= 1 && lovingImpostorEnabled;
             if (!canMakeCrewCrewLovers && !canMakeCrewImpostorLovers) {
                 return;
             }
 
-            var lovingImpostor = canMakeCrewImpostorLovers;
+            bool lovingImpostor = canMakeCrewImpostorLovers;
 
             var num = Random.RandomRangeInt(0, crewmates.Count);
             var player1 = crewmates[num];


### PR DESCRIPTION
Loving Impostor is no longer a percentage; it's been changed to a checkbox. In addition, originally you could have a solo Impostor be a Lover but that was inadvertently changed. Solo Loving Impostor is restored.