### PR TITLE
Can't Report Voted Lover option

### DIFF
--- a/source/Patches/CrewmateRoles/LoversMod/Die.cs
+++ b/source/Patches/CrewmateRoles/LoversMod/Die.cs
@@ -1,4 +1,5 @@
 using HarmonyLib;
+using Hazel; //need Hazel for RPC
 using TownOfUs.CrewmateRoles.AltruistMod;
 using TownOfUs.Roles;
 
@@ -14,12 +15,23 @@ namespace TownOfUs.CrewmateRoles.LoversMod
 
             var flag3 = __instance.isLover() && CustomGameOptions.BothLoversDie;
             if (!flag3) return true;
-            var otherLover = Role.GetRole<Lover>(__instance).OtherLover.Player;
-            if (otherLover.Data.IsDead) return true;
+            var otherLover = Role.GetRole<Lover>(__instance).OtherLover;
+            if (otherLover.Player.Data.IsDead) return true;
 
-            if (reason == DeathReason.Exile) KillButtonTarget.DontRevive = __instance.PlayerId;
+            if (reason == DeathReason.Exile)
+            {
+                KillButtonTarget.DontRevive = __instance.PlayerId;
+                // check if option are activated and turn to true, the voted indicator, then send RPC to other player for turn to true the indicator for everybody
+                if (CustomGameOptions.VotedLover && AmongUsClient.Instance.AmHost)
+                {  
+                    otherLover.Voted = true;
+                    var writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte) CustomRPC.VotedLover, SendOption.Reliable, -1);
+                    writer.Write(otherLover.Player.PlayerId);
+                    AmongUsClient.Instance.FinishRpcImmediately(writer);
+                };
+            }
 
-            if (AmongUsClient.Instance.AmHost) Utils.RpcMurderPlayer(otherLover, otherLover);
+            if (AmongUsClient.Instance.AmHost) Utils.RpcMurderPlayer(otherLover.Player, otherLover.Player);
 
             return true;
         }

--- a/source/Patches/CustomGameOptions.cs
+++ b/source/Patches/CustomGameOptions.cs
@@ -51,6 +51,7 @@ namespace TownOfUs
         public static int VanillaGame => (int) Generate.VanillaGame.Get();
         public static bool BothLoversDie => Generate.BothLoversDie.Get();
         public static int LovingImpostorOn => (int) Generate.LovingImpostorOn.Get();
+        public static bool VotedLover => Generate.VotedLover.Get();
         public static bool ShowSheriff => Generate.ShowSheriff.Get();
         public static bool SheriffKillOther => Generate.SheriffKillOther.Get();
         public static bool SheriffKillsJester => Generate.SheriffKillsJester.Get();

--- a/source/Patches/CustomOption/Generate.cs
+++ b/source/Patches/CustomOption/Generate.cs
@@ -75,6 +75,7 @@ namespace TownOfUs.CustomOption
         private static CustomHeaderOption Lovers;
         public static CustomToggleOption BothLoversDie;
         public static CustomNumberOption LovingImpostorOn;
+        public static CustomToggleOption VotedLover;
 
         private static CustomHeaderOption Sheriff;
         public static CustomToggleOption ShowSheriff;
@@ -328,6 +329,7 @@ namespace TownOfUs.CustomOption
             BothLoversDie = new CustomToggleOption(num++, "Both Lovers Die");
             LovingImpostorOn = new CustomNumberOption(num++, "Allow Loving Impostor",25f, 0f, 100f, 10f,
                 PercentFormat);
+            VotedLover = new CustomToggleOption(num++, "Can't Report Voted Lover");
 
             Sheriff =
                 new CustomHeaderOption(num++, $"{RoleDetailsAttribute.GetRoleDetails(RoleEnum.Sheriff).GetColoredName()}");

--- a/source/Patches/CustomRPC.cs
+++ b/source/Patches/CustomRPC.cs
@@ -49,6 +49,7 @@ namespace TownOfUs
 
 
         LoveWin,
+        VotedLover,
         GlitchWin,
         ArsonistWin,
         PhantomWin,

--- a/source/Patches/Roles/Lover.cs
+++ b/source/Patches/Roles/Lover.cs
@@ -21,6 +21,9 @@ namespace TownOfUs.Roles
 
         // Returns true if either lover is an impostor
         public bool LoverImpostor { get; set; }
+        
+        //add a VotedLover Indicator
+        public bool Voted = false;
 
         protected override void IntroPrefix(IntroCutscene._CoBegin_d__14 __instance)
         {

--- a/source/Patches/Roles/Role.cs
+++ b/source/Patches/Roles/Role.cs
@@ -488,6 +488,21 @@ namespace TownOfUs.Roles
             {
                 if (ExileController.Instance == null || ExileController.Instance.exiled == null) return;
 
+                // If Lover was Voted and option was activated we display the role and the other lover in the ejection text to prevent other players to replace the body appaerant
+                //anyway we would have understood that they were lovers when the otherlover dies if the option is not activated
+                var info = ExileController.Instance.exiled;
+                var role = GetRole(info.Object);
+                if (role == null) return;
+                var roleName = "";
+                if ((role.RoleType == RoleEnum.Lover || role.RoleType == RoleEnum.LoverImpostor) && CustomGameOptions.VotedLover)
+                {
+                    var lover = GetRole<Lover>(info.Object);
+                    var lover2 = lover.OtherLover.Player;
+                    roleName = $"The Lover with {lover2.Data.PlayerName}";
+                    __result = $"{info.PlayerName} was {roleName}.";
+                    return;
+                }
+
                 switch (name)
                 {
                     case StringNames.ExileTextPN:
@@ -495,10 +510,9 @@ namespace TownOfUs.Roles
                     case StringNames.ExileTextPP:
                     case StringNames.ExileTextSP:
                         {
-                            var info = ExileController.Instance.exiled;
-                            var role = GetRole(info.Object);
+                            // we move the info and role definition above, may be not need the if(role == null) return; we have already check before
                             if (role == null) return;
-                            var roleName = role.RoleType == RoleEnum.Glitch ? role.Name : $"The {role.Name}";
+                            roleName = role.RoleType == RoleEnum.Glitch ? role.Name : $"The {role.Name}";
                             __result = $"{info.PlayerName} was {roleName}.";
                             return;
                         }

--- a/source/Patches/RpcHandling.cs
+++ b/source/Patches/RpcHandling.cs
@@ -294,7 +294,13 @@ namespace TownOfUs
                         var winnerlover = Utils.PlayerById(reader.ReadByte());
                         Role.GetRole<Lover>(winnerlover).Win();
                         break;
-
+                    //RPC Turn Voted indicator for the 2 lover for more security, just 1 is very necessary. the one who dies after the meeting, but I'm not sure which one is this among the 2.
+                    case CustomRPC.VotedLover:
+                        var lover = Utils.PlayerById(reader.ReadByte());
+                        var loverRole = Role.GetRole<Lover>(lover);
+                        loverRole.Voted = true;
+                        loverRole.OtherLover.Voted = true;
+                        break;
 
                     case CustomRPC.JesterLose:
                         foreach (var role in Role.AllRoles)

--- a/source/Patches/Utils.cs
+++ b/source/Patches/Utils.cs
@@ -447,7 +447,17 @@ namespace TownOfUs
                     target.myTasks.Insert(0, importantTextTask);
                 }
 
-                killer.MyPhysics.StartCoroutine(killer.KillAnimations.Random().CoPerformKill(killer, target));
+                // perform kill without body.
+                //TODO: find a better way to perform this kill
+                if (
+                    CustomGameOptions.VotedLover &&
+                    (killer.Is(RoleEnum.Lover) ||
+                    killer.Is(RoleEnum.LoverImpostor)) &&
+                    Role.GetRole<Lover>(killer).Voted
+                )
+                    target.Data.IsDead = true;
+                else
+                    killer.MyPhysics.StartCoroutine(killer.KillAnimations.Random().CoPerformKill(killer, target));
                 var deadBody = new DeadPlayer
                 {
                     PlayerId = target.PlayerId,


### PR DESCRIPTION
Modify Lover.cs to add indicator for the Voted Lovers.
Modify LoversMod/Die.cs to add a check if option was activated in the if (reason == exile) check if true, turn indicator to true and send RPC to turn on true for all players.
Modify CustomRPC.cs Add the VotedLover RPCName.
Modify RpcHandling.cs Add the RPC Voted Lover Reaction to turn on true the indicator for the Lovers
Modify Role.cs to patch the ejection text if lover was voted and option activated to indicate the other player the fact the lovers was voted and who are the other lover.
Modify Utils.cs to patch the murderPlayer Method for perform a kill without body.
Modify Generate.cs to add the option.
Modify CustomGameOptions.cs to get the setting.