### PR TITLE
Guesser & Swapper Can Swap/Guess After Voting option

### DIFF
--- a/source/Patches/CrewmateRoles/SwapperMod/ShowHideButtons.cs
+++ b/source/Patches/CrewmateRoles/SwapperMod/ShowHideButtons.cs
@@ -41,7 +41,8 @@ namespace TownOfUs.CrewmateRoles.SwapperMod
         {
             public static bool Prefix(MeetingHud __instance)
             {
-                if (!PlayerControl.LocalPlayer.Is(RoleEnum.Swapper)) return true;
+                // If the option is activated, we don't hide button on vote confirm
+                if (!PlayerControl.LocalPlayer.Is(RoleEnum.Swapper) || CustomGameOptions.SGAfterVote) return true;
                 var swapper = Role.GetRole<Swapper>(PlayerControl.LocalPlayer);
                 foreach (var button in swapper.Buttons.Where(button => button != null))
                 {

--- a/source/Patches/CustomGameOptions.cs
+++ b/source/Patches/CustomGameOptions.cs
@@ -49,6 +49,7 @@ namespace TownOfUs
         public static int BigBoiOn => (int) Generate.BigBoiOn.Get();
         public static int ButtonBarryOn => (int) Generate.ButtonBarryOn.Get();
         public static int VanillaGame => (int) Generate.VanillaGame.Get();
+        public static bool SGAfterVote => Generate.SGAfterVote.Get();
         public static bool BothLoversDie => Generate.BothLoversDie.Get();
         public static int LovingImpostorOn => (int) Generate.LovingImpostorOn.Get();
         public static bool ShowSheriff => Generate.ShowSheriff.Get();

--- a/source/Patches/CustomOption/Generate.cs
+++ b/source/Patches/CustomOption/Generate.cs
@@ -38,6 +38,7 @@ namespace TownOfUs.CustomOption
         public static CustomNumberOption JanitorOn;
         public static CustomNumberOption MorphlingOn;
         public static CustomNumberOption CamouflagerOn;
+        public static CustomToggleOption SGAfterVote;
         public static CustomNumberOption MinerOn;
         public static CustomNumberOption SwooperOn;
         public static CustomNumberOption UndertakerOn;
@@ -302,6 +303,7 @@ namespace TownOfUs.CustomOption
                 2.5f, CooldownFormat);
             ColourblindComms = new CustomToggleOption(num++, "Camouflaged Comms", false);
             MeetingColourblind = new CustomToggleOption(num++, "Camouflaged Meetings", false);
+            SGAfterVote = new CustomToggleOption(num++, "Swapper & Guesser Can Swap/Guess After Voting", false);
             ImpostorSeeRoles = new CustomToggleOption(num++, "Impostors can see the roles of their team", false);
             DeadSeeRoles =
                 new CustomToggleOption(num++, "Dead can see everyone's roles", false);

--- a/source/Patches/Roles/IMeetingGuesser.cs
+++ b/source/Patches/Roles/IMeetingGuesser.cs
@@ -170,6 +170,8 @@ namespace TownOfUs.Roles
     {
         public static void HideButtons(IMeetingGuesser role)
         {
+            // if option is activated, we don't hide button on vote confirm
+            if (CustomGameOptions.SGAfterVote) return;
             foreach (var (_, (cycle, guess, guessText)) in role.Buttons)
             {
                 if (cycle == null) continue;


### PR DESCRIPTION
Modify SwapperMod/ShowHideButtons.cs to don't hide button on vote confirm if option is activated.
Modify IMeetingGuesser.cs to don't hide buttons on vote confirm if option is activated.
Modify Generate.cs to add the option.
Modify CustomGameOptions.cs to Get the option.