### PR TITLE
Migrate to BepInEx.IL2CPP.MSBuild

### DIFF
--- a/source/Patches/CustomHats/HatLoader.cs
+++ b/source/Patches/CustomHats/HatLoader.cs
@@ -47,7 +47,10 @@ namespace TownOfUs.Patches.CustomHats
         private static HatMetadataJson LoadJson()
         {
             var stream = Assembly.GetManifestResourceStream($"{HAT_RESOURCE_NAMESPACE}.{HAT_METADATA_JSON}");
-            return JsonConvert.DeserializeObject<HatMetadataJson>(Encoding.UTF8.GetString(stream.ReadFully()));
+            
+            // The only JsonConvert.DeserializeObject generic that is available in Among Us
+            return JsonConvert.DeserializeObject<HatMetadataJson>(Encoding.UTF8.GetString(stream.ReadFully()), 
+                new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto });
         }
 
         private static List<HatBehaviour> DiscoverHatBehaviours(HatMetadataJson metadata)

--- a/source/Patches/CustomHats/HatLoader.cs
+++ b/source/Patches/CustomHats/HatLoader.cs
@@ -49,8 +49,7 @@ namespace TownOfUs.Patches.CustomHats
             var stream = Assembly.GetManifestResourceStream($"{HAT_RESOURCE_NAMESPACE}.{HAT_METADATA_JSON}");
             
             // The only JsonConvert.DeserializeObject generic that is available in Among Us
-            return JsonConvert.DeserializeObject<HatMetadataJson>(Encoding.UTF8.GetString(stream.ReadFully()), 
-                new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto });
+            return JsonConvert.DeserializeObject<HatMetadataJson>(Encoding.UTF8.GetString(stream.ReadFully()), (​JsonSerializerSettings​)​ null​);
         }
 
         private static List<HatBehaviour> DiscoverHatBehaviours(HatMetadataJson metadata)

--- a/source/Patches/CustomHats/HatLoader.cs
+++ b/source/Patches/CustomHats/HatLoader.cs
@@ -49,7 +49,7 @@ namespace TownOfUs.Patches.CustomHats
             var stream = Assembly.GetManifestResourceStream($"{HAT_RESOURCE_NAMESPACE}.{HAT_METADATA_JSON}");
             
             // The only JsonConvert.DeserializeObject generic that is available in Among Us
-            return JsonConvert.DeserializeObject<HatMetadataJson>(Encoding.UTF8.GetString(stream.ReadFully()), (​JsonSerializerSettings​)​ null​);
+            return JsonConvert.DeserializeObject<HatMetadataJson>(Encoding.UTF8.GetString(stream.ReadFully()), (JsonSerializerSettings) null);
         }
 
         private static List<HatBehaviour> DiscoverHatBehaviours(HatMetadataJson metadata)

--- a/source/TownOfUs.csproj
+++ b/source/TownOfUs.csproj
@@ -6,15 +6,18 @@
     <Version>2.6.3</Version>
     <DebugType>embedded</DebugType>
   </PropertyGroup>
-  
+
   <PropertyGroup>
-    <GameProvider>Github</GameProvider>
-    <GameVersion>2021.6.30s</GameVersion>
+    <GamePlatform Condition="'$(GamePlatform)' == ''">Steam</GamePlatform>
+    <GameVersion Condition="'$(GamePlatform)' == 'Steam'">2021.6.30</GameVersion>
+    <GameVersion Condition="'$(GamePlatform)' == 'Itch'">2021.6.30</GameVersion>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Reactor" Version="1.0.0-rc.1" />
-    <PackageReference Include="Reactor.MSBuild" Version="0.1.5" />
+    <PackageReference Include="Reactor" Version="1.1.0" />
+    <PackageReference Include="BepInEx.IL2CPP" Version="6.0.0-be.525" />
+    <PackageReference Include="AmongUs.GameLibs.$(GamePlatform)" Version="$(GameVersion)" PrivateAssets="all" />
+    <PackageReference Include="BepInEx.IL2CPP.MSBuild" Version="1.0.2" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/nuget.config
+++ b/source/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<configuration>
+    <packageSources>
+        <add key="BepInEx" value="https://nuget.bepinex.dev/v3/index.json" />
+    </packageSources>
+</configuration>


### PR DESCRIPTION
As `Reactor.MSBuild` support has been discontinued, it is recommended to use the new `BepInEx.IL2CPP.MSBuild` with Among Us game library.