### PR TITLE
TOU Handshake Rework

### DIFF
--- a/source/Patches/CustomRPC.cs
+++ b/source/Patches/CustomRPC.cs
@@ -104,5 +104,6 @@ namespace TownOfUs
         FixAnimation,
 
         AddMayorVoteBank,
+        HostToClientHandshake,
     }
 }

--- a/source/Patches/Handshake/ClientHandshake.cs
+++ b/source/Patches/Handshake/ClientHandshake.cs
@@ -13,7 +13,7 @@ namespace TownOfUs.Handshake
     {
         public static bool hideLobbyCode = false;
         //this should really be automated.
-        const string auVersion = "2021-06-30";
+        const string auVersion = "2021-12-15";
         //do not change unless you are forking TOU to make your own variation on the mod, this is used to identify different forks of the same mod only.
         const string touForkName = "Anusien";
         public static System.Version touVersion = System.Version.Parse(TownOfUs.GetVersion());

--- a/source/Patches/Handshake/ClientHandshake.cs
+++ b/source/Patches/Handshake/ClientHandshake.cs
@@ -285,19 +285,5 @@ namespace TownOfUs.Handshake
             Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogDebug($"auVersion={auVersion}");
             logVersion(auVersion, touVersion, guid, forkName, clientId);
         }
-
-        private static void SendCustomDisconnect(this InnerNetClient innerNetClient, int clientId, string message)
-        {
-            var messageWriter = MessageWriter.Get(SendOption.Reliable);
-            messageWriter.StartMessage(11);
-            messageWriter.Write(innerNetClient.GameId);
-            messageWriter.WritePacked(clientId);
-            messageWriter.Write(false);
-            messageWriter.Write(8);
-            messageWriter.Write(message);
-            messageWriter.EndMessage();
-            innerNetClient.SendOrDisconnect(messageWriter);
-            messageWriter.Recycle();
-        }
     }
 }

--- a/source/Patches/Handshake/ClientHandshake.cs
+++ b/source/Patches/Handshake/ClientHandshake.cs
@@ -1,111 +1,292 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using HarmonyLib;
+﻿using HarmonyLib;
 using Hazel;
 using InnerNet;
-using Reactor;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using UnhollowerBaseLib;
 using UnityEngine;
 
 namespace TownOfUs.Handshake
 {
     public static class ClientHandshake
     {
-        private const byte TOU_ROOT_HANDSHAKE_TAG = 69;
+        public static bool hideLobbyCode = false;
+        //this should really be automated.
+        const string auVersion = "2021-06-30";
+        //do not change unless you are forking TOU to make your own variation on the mod, this is used to identify different forks of the same mod only.
+        const string touForkName = "Anusien";
+        public static System.Version touVersion = System.Version.Parse(TownOfUs.GetVersion());
 
-        [HarmonyPatch(typeof(AmongUsClient), nameof(AmongUsClient.OnGameJoined))]
-        public static class AmongUsClient_OnGameJoined
+        private static float timer = 600f;
+        private static float kickingTimer = 0f;
+        private static float kickingTimerMax = 20f;
+        private static bool versionSent = false;
+        private static string lobbyCodeText = "";
+
+        public static Dictionary<int, PlayerVersionInfo> playerVersions = new Dictionary<int, PlayerVersionInfo>();
+
+        [HarmonyPatch(typeof(AmongUsClient), nameof(AmongUsClient.OnPlayerJoined))]
+        public class AmongUsClientOnPlayerJoinedPatch
         {
-            public static void Postfix(AmongUsClient __instance)
+            public static void Postfix()
             {
-                if (AmongUsClient.Instance.AmHost)
-                    return;
-
-                // If I am client, send handshake
-                PluginSingleton<TownOfUs>.Instance.Log.LogMessage($"AmongUsClient.OnGameJoined.Postfix - Am client, sending handshake");
-                var messageWriter = MessageWriter.Get(SendOption.Reliable);
-                messageWriter.StartMessage(6);
-                messageWriter.Write(__instance.GameId);
-                messageWriter.WritePacked(__instance.HostId);
-                messageWriter.StartMessage(TOU_ROOT_HANDSHAKE_TAG);
-                messageWriter.Write(AmongUsClient.Instance.ClientId);
-                messageWriter.Write(TownOfUs.GetVersion());
-                messageWriter.EndMessage();
-                messageWriter.EndMessage();
-                __instance.SendOrDisconnect(messageWriter);
-                messageWriter.Recycle();
+                if (PlayerControl.LocalPlayer != null)
+                {
+                    sendVersion();
+                }
             }
         }
 
-        [HarmonyPatch(typeof(InnerNetClient), nameof(InnerNetClient.HandleGameData))]
-        public static class InnerNetClient_HandleGameData
+        [HarmonyPatch(typeof(GameStartManager), nameof(GameStartManager.Start))]
+        public class GameStartManagerStartPatch
         {
-            public static bool Prefix(InnerNetClient __instance,
-                [HarmonyArgument(0)] MessageReader reader)
+            public static void Postfix(GameStartManager __instance)
             {
-                // If i am host, respond to handshake
-                if (__instance.AmHost && reader.BytesRemaining > 3)
+                // Trigger version refresh
+                versionSent = false;
+                // Reset lobby countdown timer
+                timer = 600f;
+                // Reset kicking timer
+                kickingTimer = 0f;
+                // Copy lobby code
+                string code = InnerNet.GameCode.IntToGameName(AmongUsClient.Instance.GameId);
+                GUIUtility.systemCopyBuffer = code;
+                lobbyCodeText = DestroyableSingleton<TranslationController>.Instance.GetString(StringNames.RoomCode, new Il2CppReferenceArray<Il2CppSystem.Object>(0)) + "\r\n" + code;
+            }
+        }
+
+        [HarmonyPatch(typeof(GameStartManager), nameof(GameStartManager.Update))]
+        public class GameStartManagerUpdatePatch
+        {
+            private static bool update = false;
+            private static string currentText = "";
+
+            public static void Prefix(GameStartManager __instance)
+            {
+                if (!AmongUsClient.Instance.AmHost || !GameData.Instance) return; // Not host or no instance
+                update = GameData.Instance.PlayerCount != __instance.LastPlayerCount;
+            }
+
+            public static void Postfix(GameStartManager __instance)
+            {
+                // Send version as soon as PlayerControl.LocalPlayer exists
+                if (PlayerControl.LocalPlayer != null && !versionSent)
                 {
-                    var handshakeReader = MessageReader.Get(reader).ReadMessageAsNewBuffer();
-                    if (handshakeReader.Tag == TOU_ROOT_HANDSHAKE_TAG)
+                    versionSent = true;
+                    sendVersion();
+                }
+
+                // Host update with version handshake infos
+                if (AmongUsClient.Instance.AmHost)
+                {
+                    bool blockStart = false;
+                    string message = "";
+                    
+                    foreach (InnerNet.ClientData client in AmongUsClient.Instance.allClients.ToArray())
                     {
-                        PluginSingleton<TownOfUs>.Instance.Log.LogMessage($"InnerNetClient.HandleMessage.Prefix - Host recieved TOU handshake");
-
-                        var clientId = handshakeReader.ReadInt32();
-                        var touVersion = handshakeReader.ReadString();
-
-                        // List<int> HandshakedClients - exists to disconnect legacy clients that don't send handshake
-                        PluginSingleton<TownOfUs>.Instance.Log.LogMessage($"InnerNetClient.HandleMessage.Prefix - Adding {clientId} with TOU version {touVersion} to List<int>HandshakedClients");
-                        HandshakedClients.Add(clientId);
-
-                        if (!TownOfUs.GetVersion().Equals(touVersion))
+                        if (client.Character == null) continue;
+                        var dummyComponent = client.Character.GetComponent<DummyBehaviour>();
+                        if (dummyComponent != null && dummyComponent.enabled)
+                            continue;
+                        else if (!playerVersions.ContainsKey(client.Id))
                         {
-                            PluginSingleton<TownOfUs>.Instance.Log.LogMessage($"InnerNetClient.HandleMessage.Prefix - ClientId {clientId} has mismatched TOU version {touVersion}. (Ours is {TownOfUs.GetVersion()})");
-                            __instance.SendCustomDisconnect(clientId);
+                            blockStart = true;
+                            Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogMessage($"ClientHandshake --- {client.Character.Data.PlayerName} has a different or no version of Town Of Us");
+                            message += $"<color=#FF0000FF>{client.Character.Data.PlayerName} has a different or no version of Town Of Us\n</color>";
                         }
-
-                        return false;
+                        else
+                        {
+                            PlayerVersionInfo playerVI = playerVersions[client.Id];
+                            int diff = touVersion.CompareTo(playerVI.touVersion);
+                            if (diff > 0)
+                            {
+                                Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogMessage($"ClientHandshake --- {client.Character.Data.PlayerName} has an older version of Town Of Us (v{playerVI.touVersion.ToString()})");
+                                message += $"<color=#FF0000FF>{client.Character.Data.PlayerName} has an older version of Town Of Us (v{playerVI.touVersion.ToString()})\n</color>";
+                                blockStart = true;
+                            }
+                            else if (diff < 0)
+                            {
+                                Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogMessage($"ClientHandshake --- {client.Character.Data.PlayerName} has a newer version of Town Of Us (v{playerVI.touVersion.ToString()})");
+                                message += $"<color=#FF0000FF>{client.Character.Data.PlayerName} has a newer version of Town Of Us (v{playerVI.touVersion.ToString()})\n</color>";
+                                blockStart = true;
+                            }
+                            else if (playerVI.guid!=Assembly.GetExecutingAssembly().ManifestModule.ModuleVersionId)
+                            { // different guid but same version = modified/different fork/different mod, so shows the fork name.
+                                Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogMessage($"ClientHandshake --- {client.Character.Data.PlayerName} has a modified version of TOU v{playerVI.touVersion.ToString()} - [{playerVI.forkName}]({playerVI.guid.ToString()})");
+                                message += $"<color=#FF0000FF>{client.Character.Data.PlayerName} has a modified version of TOU v{playerVI.touVersion.ToString()}\n<size=75%>[{playerVI.forkName}]({playerVI.guid.ToString()})</size>\n</color>";
+                                blockStart = true;
+                            }
+                        }
+                    }
+                    if (blockStart)
+                    {
+                        __instance.StartButton.color = __instance.startLabelText.color = Palette.DisabledClear;
+                        __instance.GameStartText.text = message;
+                        __instance.GameStartText.transform.localPosition = __instance.StartButton.transform.localPosition + Vector3.up * 2;
+                    }
+                    else
+                    {
+                        __instance.StartButton.color = __instance.startLabelText.color = ((__instance.LastPlayerCount >= __instance.MinPlayers) ? Palette.EnabledColor : Palette.DisabledClear);
+                        __instance.GameStartText.transform.localPosition = __instance.StartButton.transform.localPosition;
                     }
                 }
 
-                return true;
+
+                // Client update with handshake infos
+                if (!AmongUsClient.Instance.AmHost)
+                {
+                    string message = "";
+
+                    //for auto update mod coming soon.
+                    bool triggerUpdate = false;
+                    string hostVersion = "";
+
+                    PlayerVersionInfo hostVI = playerVersions[AmongUsClient.Instance.HostId];
+                    int diff = touVersion.CompareTo(hostVI.touVersion);
+                    if (!playerVersions.ContainsKey(AmongUsClient.Instance.HostId) || touVersion.CompareTo(hostVI.touVersion) != 0 || Assembly.GetExecutingAssembly().ManifestModule.ModuleVersionId != hostVI.guid)
+                    {
+                        kickingTimer += Time.deltaTime;
+                        if (kickingTimer > kickingTimerMax)
+                        {
+                            kickingTimer = 0;
+                            AmongUsClient.Instance.ExitGame(DisconnectReasons.ExitGame);
+                            SceneChanger.ChangeScene("MainMenu");
+                        }
+                        if (!playerVersions.ContainsKey(AmongUsClient.Instance.HostId))
+                        {
+                            Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogMessage($"ClientHandshake --- The Host({AmongUsClient.Instance.GetHost().PlayerName}) is not a Town Of Us Host");
+                            message += $"<color=#FF0000FF>The Host({AmongUsClient.Instance.GetHost().PlayerName}) is not a Town Of Us Host\nYou will be kicked in {Math.Round(10 - kickingTimer)} seconds.</color>";
+                        }
+                        else if (diff > 0)
+                        {
+                            Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogMessage($"ClientHandshake --- The Host({AmongUsClient.Instance.GetHost().PlayerName}) has an older version of Town Of Us (v{hostVI.touVersion.ToString()})");
+                            message += $"<color=#FF0000FF>The Host({AmongUsClient.Instance.GetHost().PlayerName}) has an older version of Town Of Us (v{hostVI.touVersion.ToString()})\nYou will be kicked in {Math.Round(kickingTimerMax - kickingTimer)} seconds.</color>";
+                            //for linking up with the auto mod update
+                            triggerUpdate = true;
+                            hostVersion = hostVI.touVersion.ToString();
+                        }
+                        else if (diff < 0)
+                        {
+                            Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogMessage($"ClientHandshake --- The Host({AmongUsClient.Instance.GetHost().PlayerName}) has a newer version of Town Of Us (v{hostVI.touVersion.ToString()})");
+                            message += $"<color=#FF0000FF>The Host({AmongUsClient.Instance.GetHost().PlayerName}) has a newer version of Town Of Us (v{hostVI.touVersion.ToString()})\nYou will be kicked in {Math.Round(kickingTimerMax - kickingTimer)} seconds.</color>";
+                            //for linking up with the auto mod update
+                            triggerUpdate = true;
+                            hostVersion = hostVI.touVersion.ToString();
+                        }
+                        else if (Assembly.GetExecutingAssembly().ManifestModule.ModuleVersionId != hostVI.guid)
+                        {
+                            Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogMessage($"ClientHandshake --- The Host({AmongUsClient.Instance.GetHost().PlayerName}) has a modified version of TOU v{hostVI.touVersion.ToString()} - [Fork:- {hostVI.forkName}](GUID:-{hostVI.guid.ToString()})");
+                            message += $"<color=#FF0000FF>The Host({AmongUsClient.Instance.GetHost().PlayerName}) has a modified version of TOU v{hostVI.touVersion.ToString()}\n<size=75%>[Fork:- {hostVI.forkName}](GUID:-{hostVI.guid.ToString()})</size>\nYou will be kicked in {Math.Round(kickingTimerMax - kickingTimer)} seconds.</color>";
+                            triggerUpdate = true;
+                            hostVersion = hostVI.touVersion.ToString();
+                        }
+                        
+                        __instance.GameStartText.text = message;
+                        __instance.GameStartText.transform.localPosition = __instance.StartButton.transform.localPosition + Vector3.up * 2;
+                        if (triggerUpdate == true && kickingTimer == kickingTimerMax)
+                        {
+                            //do auto update --- not implemented yet as the auto update system is not implemented yet.
+                            //basically.. after lobby disconnect...
+                            //trigger an auto update to save the user having to re-open the game...
+                            //the version it should be updating to is 'hostversion'
+                            //this will require a change to the RPC
+                        }
+                    }
+                    else
+                    {
+                        __instance.GameStartText.transform.localPosition = __instance.StartButton.transform.localPosition;
+                        if (__instance.startState != GameStartManager.StartingStates.Countdown)
+                        {
+                            __instance.GameStartText.text = String.Empty;
+                        }
+                    }
+                }
+
+                // Lobby code replacement
+                __instance.GameRoomName.text = hideLobbyCode ? $"<color=#FF0000FF>TownOfUs</color>" : lobbyCodeText;
+
+                // Lobby timer
+                if (!AmongUsClient.Instance.AmHost || !GameData.Instance) return; // Not host or no instance
+
+                if (update) currentText = __instance.PlayerCounter.text;
+
+                timer = Mathf.Max(0f, timer -= Time.deltaTime);
+                int minutes = (int)timer / 60;
+                int seconds = (int)timer % 60;
+                string suffix = $" ({minutes:00}:{seconds:00})";
+
+                __instance.PlayerCounter.text = currentText + suffix;
+                __instance.PlayerCounter.autoSizeTextContainer = true;
             }
         }
 
-        // Handle legacy clients that don't send handshakes
-        private static HashSet<int> HandshakedClients = new HashSet<int>();
-        private static IEnumerator WaitForHandshake(InnerNetClient innerNetClient, int clientId)
+        public static void sendVersion()
         {
-            PluginSingleton<TownOfUs>.Instance.Log.LogMessage($"WaitForHandshake(innerNetClient, clientId = {clientId})");
+            MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.HostToClientHandshake, Hazel.SendOption.Reliable, -1);
+            //write client id = 1 byte read byte
+            writer.WritePacked(AmongUsClient.Instance.ClientId);
+            //write guid = 16 bytes, read packed int
+            writer.Write(Assembly.GetExecutingAssembly().ManifestModule.ModuleVersionId.ToByteArray());
+            //write forkname = flexible length, read string
+            writer.Write(touForkName);
+            //write tou version.. this should be 5 or 7 bytes long, read string
+            writer.Write(TownOfUs.GetVersion());
+            //write among us version.. read string for this.
+            writer.Write(auVersion);
+            AmongUsClient.Instance.FinishRpcImmediately(writer);
+            logVersion(auVersion, TownOfUs.GetVersion(), Assembly.GetExecutingAssembly().ManifestModule.ModuleVersionId, touForkName, AmongUsClient.Instance.ClientId);
+        }
 
-            yield return new WaitForSeconds(5f);
-            PluginSingleton<TownOfUs>.Instance.Log.LogMessage($"WaitForHandshake() - Waited 5 seconds");
-            if (!HandshakedClients.Contains(clientId))
+        public class PlayerVersionInfo
+        {
+            public string auVersion { get; set; }
+            public System.Version touVersion { get; set; }
+            public string forkName { get; set; }
+            public Guid guid { get; set; }
+
+            public PlayerVersionInfo(string auVersion, Version touVersion, string forkName, Guid guid)
             {
-                PluginSingleton<TownOfUs>.Instance.Log.LogMessage($"WaitForHandshake() - HandshakedClients did not contain clientId {clientId}");
-                if (innerNetClient.allClients.ToArray().Any(x => x.Id == clientId))
-                    innerNetClient.SendCustomDisconnect(clientId);
+                this.auVersion = auVersion;
+                this.touVersion = touVersion;
+                this.forkName = forkName;
+                this.guid = guid;
+            }
+        }
+
+        public static void logVersion(string auVersion, string touVersion, Guid guid, string touFork, int clientId)
+        {
+            System.Version touVer = new System.Version(touVersion);
+            playerVersions[clientId] = new PlayerVersionInfo(auVersion, touVer, touFork, guid);
+        }
+
+        public static void readHandshakeViaRPC(MessageReader reader)
+        {
+            int clientId = reader.ReadPackedInt32();
+            Guid guid;
+            if (reader.Length - reader.Position >= 16)
+            {
+                // GUID
+                byte[] gbytes = reader.ReadBytes(16);
+                guid = new Guid(gbytes);
             }
             else
             {
-                PluginSingleton<TownOfUs>.Instance.Log.LogMessage($"WaitForHandshake() - HandshakedClients contained clientId {clientId}");
+                guid = new Guid(new byte[16]);
             }
+            string forkName = reader.ReadString();
+            string touVersion = reader.ReadString();
+            string auVersion = reader.ReadString();
+
+            Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogDebug($"ClientID={clientId}");
+            Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogDebug($"GUID={guid}");
+            Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogDebug($"forkName={forkName}");
+            Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogDebug($"touVersion={touVersion}");
+            Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogDebug($"auVersion={auVersion}");
+            logVersion(auVersion, touVersion, guid, forkName, clientId);
         }
 
-        [HarmonyPatch(typeof(AmongUsClient), nameof(AmongUsClient.OnPlayerJoined))]
-        public static class AmongUsClient_OnPlayerJoined
-        {
-            public static void Postfix(AmongUsClient __instance, [HarmonyArgument(0)] ClientData data)
-            {
-                if (AmongUsClient.Instance.AmHost && __instance.GameState == InnerNetClient.GameStates.Started)
-                {
-                    PluginSingleton<TownOfUs>.Instance.Log.LogMessage($"Am host and clientId {data.Id} sent JoinGameResponse");
-                    Coroutines.Start(WaitForHandshake(__instance, data.Id));
-                }
-            }
-        }
-
-        private static void SendCustomDisconnect(this InnerNetClient innerNetClient, int clientId)
+        private static void SendCustomDisconnect(this InnerNetClient innerNetClient, int clientId, string message)
         {
             var messageWriter = MessageWriter.Get(SendOption.Reliable);
             messageWriter.StartMessage(11);
@@ -113,7 +294,7 @@ namespace TownOfUs.Handshake
             messageWriter.WritePacked(clientId);
             messageWriter.Write(false);
             messageWriter.Write(8);
-            messageWriter.Write($"The host has a different version of Town Of Us ({TownOfUs.GetVersion()})");
+            messageWriter.Write(message);
             messageWriter.EndMessage();
             innerNetClient.SendOrDisconnect(messageWriter);
             messageWriter.Recycle();

--- a/source/Patches/RpcHandling.cs
+++ b/source/Patches/RpcHandling.cs
@@ -774,6 +774,9 @@ namespace TownOfUs
                     case CustomRPC.AddMayorVoteBank:
                         Role.GetRole<Mayor>(Utils.PlayerById(reader.ReadByte())).VoteBank += reader.ReadInt32();
                         break;
+                    case CustomRPC.HostToClientHandshake:
+                        Handshake.ClientHandshake.readHandshakeViaRPC(reader);
+                        break;
                 }
             }
         }


### PR DESCRIPTION
@Anusien  - this works so if it passes your testing (ive used 2 clients for every scenario.. different versions newer/older and same versions with different fork name's) and it works as expected on both ends, the only thing i cant 100% confirm is if it fixes the crash, but as ive played TOU with the TOR handshake (https://github.com/VirusTLNR/Town-Of-Us/tree/HandshakeFixOn2.8.1) and there was no crash, and this is a minor change from that, this will also not crash.

I wanted to use knowledge from the TOR handshake to make a new handshake for TOU. but, in order to add another feature interlinking with the handshake in the future (auto updating the mod like TOR does but hopefully with more features), the handshake has to more closely resemble TORs one, so I am disappointed to say this is less brand new code than i wanted as i had to make use of the TOR template for a handshake, but made a few improvements, and put a placeholder in for where this can link into the auto updating of the mod (if that will even work as i havent tested it yet.).

Either way, this fixes the crash bug, and ive left in the lobby features that were in the TOR handshake, because why remove them? they are great features. i have hardcoded some to just work properly so settings can be coded in for them at a later date, and for other things ive implemented them as is as the features are just helpful (like the lobby timer)

Credit should go to TOR for the handshake template/design as well as the additional features, i have modified it a bit and thrown in a few extras/improvements, otherwiise it pretty much follows hows theirs works.