### PR TITLE
Add BepInEx NuGet Repo to project config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <!-- Add this repository to the list of available repositories -->
+        <add key="BepInEx" value="https://nuget.bepinex.dev/v3/index.json" />
+    </packageSources>
+</configuration>


### PR DESCRIPTION
adds  https://nuget.bepinex.dev/v3/index.json to nuget repo selection so that the packages from the bepnix repo can be downloaded/edited/updated

hopefully this also fixes the auto build test on github