### PR TITLE
Upgraded End Game Summary

### DIFF
--- a/source/Patches/EndGameSummary.cs
+++ b/source/Patches/EndGameSummary.cs
@@ -2,23 +2,29 @@
 using System.Collections.Generic;
 using System.Text;
 using UnityEngine;
+using TownOfUs.Extensions;
 using TownOfUs.Roles;
 using TownOfUs.Roles.Modifiers;
 using HarmonyLib;
+using System.Linq;
 
 namespace TownOfUs.Patches
 {
     [HarmonyPatch]
     static class EndGameSummary
     {
-        static class AdditionalTempData
+        public static class AdditionalTempData
         {
+            public static bool updateFlag = false;
             public static List<PlayerInfo> playerData = new List<PlayerInfo>();
+            public static List<KeyValuePair<byte, Role>> roleHistory = new List<KeyValuePair<byte, Role>>();
+            public static List<Tuple<string, string>> summaryTextLines = new List<Tuple<string, string>>();
 
-            //leaving this in as i assume it maybe needed in future, feel free to remove if you think otherwise.
             public static void clear()
             {
                 playerData.Clear();
+                roleHistory.Clear();
+                summaryTextLines.Clear();
             }
 
             internal class PlayerInfo
@@ -33,14 +39,49 @@ namespace TownOfUs.Patches
             }
         }
 
+        [HarmonyPatch(typeof(HudManager), nameof(HudManager.Update))]
+        [HarmonyPriority(Priority.Last)]
+        public static void Postfix(HudManager __instance)
+        {
+            if (EndGameSummary.AdditionalTempData.updateFlag)
+            {
+                //EndGameSummary.TrackRoleHistory();
+                EndGameSummary.UpdatePlayerInfo();
+            }
+        }
+
+        public static void TrackRoleHistory()
+        {
+
+            //this might work better if disconnections seem to be a problem.. player.name would need changing to player.PlayerName though.
+            //foreach (var player in GameData.Instance.AllPlayers)
+            foreach (var player in PlayerControl.AllPlayerControls)
+            {
+                var role = Role.GetRole(player);
+                if (role != null && (AdditionalTempData.roleHistory.FindAll(x => x.Key == player.PlayerId).Count==0 ||AdditionalTempData.roleHistory.Last(x => x.Key == player.PlayerId).Value != role))
+                {
+                    AdditionalTempData.roleHistory.Add(KeyValuePair.Create(player.PlayerId, role));
+                    Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogDebug($"-----------RoleChangeStart--------");
+                    Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogDebug($"RC-PlayerID={player.PlayerId}, playername:-{player.name}");
+                    Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogDebug($"RC-tKey={AdditionalTempData.roleHistory.FindLast(x => x.Key == player.PlayerId).Key}");
+                    Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogDebug($"RC-Value={AdditionalTempData.roleHistory.FindLast(x => x.Key == player.PlayerId).Value}");
+                    Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogDebug($"RC-Count={AdditionalTempData.roleHistory.FindAll(x => x.Key == player.PlayerId).Count}");
+                    Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogDebug($"RC-Total={AdditionalTempData.roleHistory.Count}");
+                    Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogDebug($"------------RoleChangeEnd---------");
+                }
+            }
+        }
+
         public static void UpdatePlayerInfo()
         {
+            TrackRoleHistory();
             List<AdditionalTempData.PlayerInfo> pinfolist = new List<AdditionalTempData.PlayerInfo>();
 
             foreach (GameData.PlayerInfo player in GameData.Instance.AllPlayers)
             {
                 AdditionalTempData.PlayerInfo pinfo = new AdditionalTempData.PlayerInfo();
                 byte pid = player.PlayerId;
+                pinfo.PlayerId = player.PlayerId;
                 pinfo.PlayerName = player.PlayerName;
                 pinfo.CurrentRole = Role.GetRole(player);
                 pinfo.Faction = pinfo.CurrentRole.Faction;
@@ -60,12 +101,16 @@ namespace TownOfUs.Patches
             }
             //added this in so when the summary is shown it does not reveal the player join order
             //, which can be used to decipher who is crew (for example on the keys task on polus)
+            //the summary now sorts by winner when loaded later, so this just makes winners and losers..
+            //...have a random order, but winners always at the top now.
             pinfolist.Shuffle();
             AdditionalTempData.playerData = pinfolist;
+            AdditionalTempData.updateFlag = true;
         }
 
         public static void LoadGameSummary(EndGameManager __instance)
         {
+            AdditionalTempData.updateFlag = false;
             var position = Camera.main.ViewportToWorldPoint(new Vector3(0f, 1f, Camera.main.nearClipPlane));
             GameObject roleSummary = UnityEngine.Object.Instantiate(__instance.WinText.gameObject);
             roleSummary.transform.position = new Vector3(__instance.Navigation.ExitButton.transform.position.x + 0.1f, position.y - 0.1f, -14f);
@@ -77,7 +122,7 @@ namespace TownOfUs.Patches
 
             foreach (var data in AdditionalTempData.playerData)
             {
-
+                var pid = data.PlayerId;
                 //this way works 100%.
                 /*var won = "   ";
                 foreach (WinningPlayerData winner in TempData.winners)
@@ -118,16 +163,72 @@ namespace TownOfUs.Patches
 
                 string roleInfo = "";
                 string modifierInfo = "";
-                if (data.CurrentRole!=null)
+                if (data.CurrentRole != null)
                 {
                     roleInfo = $"{data.CurrentRole.ColorString}{data.CurrentRole.Name}</color>";
                 }
-                if (data.Modifier!=null)
+                if (data.Modifier != null)
                 {
                     modifierInfo = $"{data.Modifier.ColorString}{data.Modifier.Name}</color> ";
                 }
-                roleSummaryText.AppendLine($"{won}{nameinfo} the {modifierInfo}{roleInfo}{taskInfo}");
+
+                //role tracking display
+                string rhInfo = "";
+                int countOfRoles = 0;
+                string setNewLine = "";
+                
+                //sets how many roles show per line in the role history, reduce in case the roles overlap into the victory/defeat message in the middle
+                int rolesPerLine = 4;
+                Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogDebug($"------------------------------------------------------------------------------------");
+                Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogDebug($"RoleHistoryLoop-before-totalrolehistorycount:-{AdditionalTempData.roleHistory.Count}");
+                Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogDebug($"------------------------------------------------------------------------------------");
+
+                foreach (var roleHistory in AdditionalTempData.roleHistory)
+                {
+                    Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogDebug($"RoleHistoryLoop-PID.:-{pid} / roleHistory.Key:-{roleHistory.Key}");
+                    if (roleHistory.Key==pid)
+                    {
+                        countOfRoles++;
+                        setNewLine = "";
+                        if((countOfRoles % rolesPerLine)==0)
+                        {
+                            setNewLine = $"\n      ";
+                        }
+                        Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogDebug($"RoleHistoryLoop-CountOFRoles.:-{countOfRoles} / setnewline:-{setNewLine}");
+                        Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogDebug($"RoleHistoryLoop-CountOFRoles % rolesperline.:-{(countOfRoles % rolesPerLine)}");
+                        Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogDebug($"EGS-PlayerName:-{data.PlayerName} --- playerID:-{pid}(also {roleHistory.Key}) --- RoleName:-{roleHistory.Value.Name}");
+                        rhInfo += $"{roleHistory.Value.ColorString}{roleHistory.Value.Name}</color>{setNewLine} > ";
+                    }
+                }
+
+                Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogDebug($"rhinfo=#{rhInfo}#");
+                Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogDebug($"rhinfolength={rhInfo.Length}"); 
+                Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogDebug($"currentrolelength={data.CurrentRole.Name.Length}");
+                Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogDebug($"combinedString={String.Concat(data.CurrentRole.ColorString, data.CurrentRole.Name + "</color>").Length + 3 + setNewLine.Length}");
+
+                if (rhInfo.Length > String.Concat(data.CurrentRole.ColorString,data.CurrentRole.Name+"</color>").Length+3+setNewLine.Length)
+                {
+                    rhInfo = rhInfo.Substring(0, rhInfo.Length - (3+setNewLine.Length));
+                    AdditionalTempData.summaryTextLines.Add(Tuple.Create(won,$"<size=80%>{won}{nameinfo} the {modifierInfo}{roleInfo}{taskInfo}</size>\n<size=60%>      {rhInfo}</size><size=40%>\n </size>"));
+                    //roleSummaryText.AppendLine($"<size=80%>{won}{nameinfo} the {modifierInfo}{roleInfo}{taskInfo}</size>\n<size=10%>\n </size><size=60%>{rhinfo}</size><size=40%>\n </size>");
+                }
+                else
+                {
+                    AdditionalTempData.summaryTextLines.Add(Tuple.Create(won, $"<size=80%>{won}{nameinfo} the {modifierInfo}{roleInfo}{taskInfo}</size>"));
+                    //roleSummaryText.AppendLine($"{won}{nameinfo} the {modifierInfo}{roleInfo}{taskInfo}");
+                }
             }
+
+
+            //sorting winners to the top, still in a randomish order.
+            AdditionalTempData.summaryTextLines = AdditionalTempData.summaryTextLines.OrderByDescending(tuple => tuple.Item1).ToList();
+            Reactor.PluginSingleton<TownOfUs>.Instance.Log.LogDebug($"SummaryTextLines.Count:-{AdditionalTempData.summaryTextLines.Count}");
+            //adding to summary text
+            foreach (Tuple<string,string> line in AdditionalTempData.summaryTextLines)
+            {
+                roleSummaryText.AppendLine(line.Item2);
+            }
+
             TMPro.TMP_Text roleSummaryTextMesh = roleSummary.GetComponent<TMPro.TMP_Text>();
             roleSummaryTextMesh.alignment = TMPro.TextAlignmentOptions.TopLeft;
             roleSummaryTextMesh.color = Color.white;

--- a/source/Patches/RpcHandling.cs
+++ b/source/Patches/RpcHandling.cs
@@ -368,8 +368,8 @@ namespace TownOfUs
                         Role.NobodyWins = false;
                         RecordRewind.points.Clear();
                         KillButtonTarget.DontRevive = byte.MaxValue;
-                        Patches.EndGameSummary.AdditionalTempData.clear();
-                        Patches.EndGameSummary.AdditionalTempData.updateFlag = true;
+                        Patches.EndGameSummary.AdditionalGameData.clear();
+                        Patches.EndGameSummary.AdditionalGameData.updateFlag = true;
                         break;
 
                     case CustomRPC.JanitorClean:
@@ -799,8 +799,8 @@ namespace TownOfUs
                 CrewmateModifiers.Clear();
                 ImpostorModifiers.Clear();
                 GlobalModifiers.Clear();
-                Patches.EndGameSummary.AdditionalTempData.clear();
-                Patches.EndGameSummary.AdditionalTempData.updateFlag = true;
+                Patches.EndGameSummary.AdditionalGameData.clear();
+                Patches.EndGameSummary.AdditionalGameData.updateFlag = true;
 
                 RecordRewind.points.Clear();
                 Murder.KilledPlayers.Clear();

--- a/source/Patches/RpcHandling.cs
+++ b/source/Patches/RpcHandling.cs
@@ -368,6 +368,8 @@ namespace TownOfUs
                         Role.NobodyWins = false;
                         RecordRewind.points.Clear();
                         KillButtonTarget.DontRevive = byte.MaxValue;
+                        Patches.EndGameSummary.AdditionalTempData.clear();
+                        Patches.EndGameSummary.AdditionalTempData.updateFlag = true;
                         break;
 
                     case CustomRPC.JanitorClean:
@@ -784,6 +786,8 @@ namespace TownOfUs
         {
             public static void Postfix()
             {
+                //for the record, this isnt an rpc.. the below clears and the rpc clears in the "start" rpc should be grouped into one method,
+                // with a call to the method both here, and in the RPC, the coding below is only run on the host client.
                 PluginSingleton<TownOfUs>.Instance.Log.LogMessage("RPC SET ROLE");
                 var infected = GameData.Instance.AllPlayers.ToArray().Where(o => o.IsImpostor());
 
@@ -795,6 +799,8 @@ namespace TownOfUs
                 CrewmateModifiers.Clear();
                 ImpostorModifiers.Clear();
                 GlobalModifiers.Clear();
+                Patches.EndGameSummary.AdditionalTempData.clear();
+                Patches.EndGameSummary.AdditionalTempData.updateFlag = true;
 
                 RecordRewind.points.Clear();
                 Murder.KilledPlayers.Clear();


### PR DESCRIPTION
changes are as follows:-
1:- player data is updated when the hud is updated (pretty much all through the game)
2:- history of roles is now tracked
3:- made the text smaller for the original game summary rows so they dont spill behind the victory/defeat picture
4:- made the role history clearly different from the main summary row
5:- all winners are sorted to be at the top, losers at the bottom (random sort order still applies.

example pictures (right one is slightly bugged but the bug is related to phantom, not this PR.
![image](https://user-images.githubusercontent.com/80432742/154377783-9646dfac-cd6f-4458-9a4e-2d56aaca429b.png)
